### PR TITLE
docs: adiciona documentacao do projeto e config de IA local

### DIFF
--- a/.aider.conf.yml
+++ b/.aider.conf.yml
@@ -1,0 +1,43 @@
+# aider — TheRogueDev, com modelo local via Ollama
+#
+#   pipx install aider-chat        (ou: python -m pip install aider-install && aider-install)
+#   aider
+#
+# OLLAMA_API_BASE ja esta definida no ambiente do usuario (http://127.0.0.1:11434).
+
+# --- Modelo -------------------------------------------------------------
+# Prefixo ollama_chat/ (nao ollama/) — o endpoint de chat rende melhor.
+# qwen-coder-dev vem do Modelfile.qwen-coder, com num_ctx=16384 travado no
+# servidor, entao nao depende do aider mandar a opcao certa.
+model: ollama_chat/qwen-coder-dev
+
+# --- O ajuste que decide se funciona ou nao -----------------------------
+# "whole" faz o modelo reescrever o arquivo inteiro em vez de emitir blocos
+# search/replace. A doc do aider recomenda para modelos locais quantizados.
+# Custo: com 16k de contexto, edite arquivos de ate ~300 linhas por vez.
+edit-format: whole
+
+# --- Git ----------------------------------------------------------------
+# Rede de seguranca: se o modelo estragar o arquivo, git diff mostra e /undo reverte.
+# Este repo ja tem commit inicial, entao /undo funciona desde o comeco.
+auto-commits: true
+dirty-commits: false
+attribute-author: false
+attribute-committer: false
+
+# --- Convencoes do projeto ---------------------------------------------
+read:
+  - AGENTS.md
+
+# --- Economia de contexto -----------------------------------------------
+# Repomap via tree-sitter e util mas come contexto. Com 16k, mantenha pequeno.
+map-tokens: 512
+
+# Nao rodar lint/teste automatico: num i7-4790K cada ciclo e lento e o modelo
+# pequeno costuma piorar o codigo tentando corrigir o proprio lint.
+auto-lint: false
+auto-test: false
+
+# --- Interface ----------------------------------------------------------
+dark-mode: true
+stream: true

--- a/.continue/rules/01-projeto.md
+++ b/.continue/rules/01-projeto.md
@@ -1,0 +1,43 @@
+---
+name: TheRogueDev — geral
+alwaysApply: true
+---
+
+# TheRogueDev — TheRogueDev-client (frontend)
+
+Plataforma gamificada de aprendizado colaborativo: grupos de estudo, fórum de
+discussões, moedas virtuais e rastreamento de contribuições.
+
+Frontend Angular 19 / TypeScript 5.7 / Tailwind 4 / Angular Material / SSR.
+O backend Spring Boot vive em outro repositorio: theroguedevapp/TheRogueDev-api.
+
+## Como você responde
+
+- Português do Brasil. Técnico e direto. Sem preâmbulo, sem "Claro!", sem resumo
+  do que você acabou de fazer.
+- Vá direto ao código.
+- Nunca invente API, método, assinatura, nome de coluna ou valor de enum.
+  Leia o arquivo-fonte antes de afirmar. Se não tem certeza, diga que não tem
+  e marque com o prefixo `[SUPOSICAO]`.
+- Antes de escrever código novo, procure um padrão parecido no projeto e siga ele.
+  Consistência vence "forma ideal".
+- Não adicione comentário explicando a correção que você fez. O código fica limpo.
+- Não abstraia na primeira ocorrência. Abstraia na segunda ou terceira variação.
+- Se faltar informação para responder, pergunte em vez de adivinhar.
+
+## Nomes
+
+**Identificadores são em inglês**: `ForumPublication`, `UserVirtualWallet`,
+`findByIdWithChildren`, `submittedBy`.
+Comentários e mensagens ao usuário final vão em português.
+
+## Segurança
+
+- Nunca logue nem exponha token JWT, senha, hash, chave RSA ou conteúdo de `.env`.
+- Query sugerida é só `SELECT`. `UPDATE`/`DELETE`/`INSERT` só com confirmação explícita.
+- Nunca proponha desabilitar validação, CORS, CSRF ou autenticação como solução de bug.
+
+## Documentação
+
+`CLAUDE.md` e os mapas do repo descrevem o projeto, mas **podem estar
+desatualizados**. Onde o documento divergir do código, o código vence.

--- a/.continue/rules/03-frontend.md
+++ b/.continue/rules/03-frontend.md
@@ -1,0 +1,63 @@
+---
+name: TheRogueDev — frontend (Angular 19)
+description: Convenções do TheRogueDev-client. Angular 19 standalone, TypeScript, Tailwind 4, Material, SSR.
+globs: "**/*.{ts,html,css,scss,json}"
+---
+
+# Frontend — TheRogueDev-client
+
+Angular 19 **standalone** — não existe NgModule. Componente novo nasce
+`standalone: true` com `imports: []` próprio.
+
+```
+src/app/
+├── pages/        # um componente por rota
+├── component/    # reutilizáveis (header, footer)
+├── services/     # base/, auth/, user/
+├── guards/       # authGuard
+├── interfaces/   # tipos de domínio
+└── enviroments/  # SIM, com esse typo. É o nome real da pasta.
+```
+
+## SSR — a pegadinha que mais quebra aqui
+
+A app roda com Angular Universal + Express. Todo código que toca `window`,
+`document`, `localStorage` ou dispara HTTP **precisa** ser guardado:
+
+```ts
+constructor(@Inject(PLATFORM_ID) private platformId: Object) {}
+if (!isPlatformBrowser(this.platformId)) { return of(null); }
+```
+
+Esquecer isso não quebra o `ng serve` — quebra o build SSR e a hidratação.
+
+## HTTP
+
+- `BaseApiService<T>` (abstrata, em `services/base/`) expõe `get/post/put/patch/delete`
+  protegidos, monta query string e já trata SSR + erro. **Service novo deve estendê-la.**
+- Estado atual: `AuthService` **não** estende `BaseApiService` — usa `HttpClient` direto
+  com `BehaviorSubject` para o usuário logado. É legado; não replique em service novo,
+  e não descreva o projeto como se tudo passasse pela base.
+- Base URL vem de `ENVIRONMENT.apiUrl` (`enviroments/enviroment.ts`) = `http://localhost:8080/api`.
+  O caminho passado ao service já começa em `/v1/...`. Nunca hardcode host.
+- JWT viaja em **cookie HTTP-only**. Não leia, não grave e não guarde token em
+  `localStorage` — o browser manda sozinho.
+
+## Estilo
+
+- Tailwind 4 + Angular Material (tema Azure Blue). Prefira utilitário Tailwind a CSS solto.
+- Cores do tema, use o nome — não o hex: `primary-color` `#171F27`, `secondary-color` `#1E2933`,
+  `emerald` `#2EC0AD` (accent/CTA), `lg-grey` `#ACB8A3`, `deep-dark` `#0E141B`,
+  `smooth-white` `#F5F7F8`, `soft-black` `#333`.
+- Ícones: Font Awesome Free 7.
+
+## Convenções
+
+- Rota nova entra em `app.routes.ts`; se for autenticada, com `canActivate: [authGuard]`.
+- RxJS: retorne `Observable`, componha com `pipe`. Faça `unsubscribe` (ou `takeUntilDestroyed`)
+  em subscription manual dentro de componente.
+- Tipos de domínio em `interfaces/`. Evite `any` em assinatura pública.
+- Existe `.spec.ts` para os componentes e services (Karma + Jasmine). Arquivo novo
+  acompanha spec, mesmo que mínimo.
+- Budget de build: 500 KB inicial (warning) / 1 MB (erro). Dependência pesada precisa
+  de justificativa.

--- a/.continueignore
+++ b/.continueignore
@@ -1,0 +1,23 @@
+# Impede o Continue de indexar lixo de build e segredos no @codebase.
+node_modules/
+.angular/
+dist/
+coverage/
+package-lock.json
+
+# Segredos
+.env
+.env.*
+src/app/enviroments/enviroment-prod.ts
+
+# Binarios e midia
+*.log
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.svg
+*.ico
+*.woff
+*.woff2
+*.ttf

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,16 @@ Thumbs.db
 
 /src/app/pages/user-profile
 
+
+### SEGREDOS ###
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.jks
+*.keystore
+
+### Lacuna: so /.angular/cache estava coberto ###
+/.angular

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+# AGENTS.md — TheRogueDev-client
+
+Regras para assistentes de código quando **esta pasta** é aberta sozinha
+(opencode, Cursor, Codex, Cline). Se você abriu o monorepo inteiro, o
+`../AGENTS.md` da raiz é o que vale — este é o recorte de frontend.
+
+Mantenha abaixo de ~1.500 tokens.
+
+---
+
+## Quem você é
+
+Assistente de programação do frontend do **TheRogueDev** — plataforma gamificada
+de aprendizado colaborativo (fórum, moedas virtuais, grupos de estudo).
+Responde em português do Brasil. Técnico e direto. Fundamenta em código lido,
+nunca em suposição. Hipótese vai com o prefixo `[SUPOSICAO]`.
+
+## Stack
+
+Angular **19.2** standalone (sem NgModule), TypeScript 5.7, Tailwind CSS 4.1,
+Angular Material 19.2 (tema Azure Blue), Font Awesome 7,
+**SSR** via Angular Universal + Express, testes com Karma + Jasmine.
+
+```
+src/app/
+├── pages/        # um componente por rota: home, login, register, user-profile
+├── component/    # reutilizáveis: header, footer
+├── services/     # base/, auth/, user/
+├── guards/       # authGuard
+├── interfaces/   # user/user.interface.ts
+└── enviroments/  # SIM, com esse typo. É o nome real da pasta.
+```
+
+## Estado real do código — leia antes de afirmar qualquer coisa
+
+O `FRONTEND.md` e o `CLAUDE.md` desta pasta descrevem um projeto mais completo do
+que o que existe. Fatos verificados no código:
+
+- **Nenhum service estende `BaseApiService`.** A classe abstrata existe em
+  `services/base/` e está pronta (get/post/put/patch/delete, query string, guarda
+  de SSR, `catchError`), mas ninguém a usa ainda.
+- `AuthService` chama `HttpClient` direto e guarda o usuário num `BehaviorSubject`.
+- **`UserService` está vazio** — só o `@Injectable` e um construtor. Não tem
+  `getProfile()` nem `updateProfile()`, apesar do que a doc diz.
+
+Ao escrever service novo: **estenda `BaseApiService<T>`**. É o alvo da arquitetura.
+Não replique o padrão do `AuthService`.
+
+## Regras
+
+### Geral
+- Vá direto ao código. Sem preâmbulo e sem resumo do que acabou de fazer.
+- Nunca invente método, rota ou campo. Leia o fonte antes de afirmar.
+- Identificadores em **inglês**; comentário e texto de UI em português.
+- Siga o padrão que já existe no arquivo, mesmo que você prefira outro.
+- Não adicione comentário explicando a correção feita.
+- Não abstraia na primeira ocorrência.
+
+### SSR — o que mais quebra aqui
+Todo acesso a `window`, `document`, `localStorage` ou HTTP precisa de guarda:
+
+```ts
+constructor(@Inject(PLATFORM_ID) private platformId: Object) {}
+if (!isPlatformBrowser(this.platformId)) { return of(null); }
+```
+
+Esquecer **não** quebra o `ng serve` — quebra o build SSR e a hidratação.
+
+### HTTP
+- Base URL vem de `ENVIRONMENT.apiUrl` (`enviroments/enviroment.ts`)
+  = `http://localhost:8080/api`. O caminho começa em `/v1/...`. Nunca hardcode host.
+- JWT viaja em **cookie HTTP-only**. Não leia, não grave, nada de `localStorage`
+  para token — o browser manda sozinho.
+- Rotas do backend são **singulares e hierárquicas**, não plural com hífen:
+  `/v1/auth/login`, `/v1/user`, `/v1/user/profile`, `/v1/forum/publication`,
+  `/v1/publication/topic`, `/v1/currency/virtual/user/wallet`.
+  Na dúvida, confira o `@RequestMapping` no backend.
+
+### Estilo
+- Tailwind 4 + Material. Prefira utilitário Tailwind a CSS solto.
+- Use o **nome** da cor, não o hex: `primary-color` `#171F27`,
+  `secondary-color` `#1E2933`, `emerald` `#2EC0AD` (accent/CTA),
+  `lg-grey` `#ACB8A3`, `deep-dark` `#0E141B`, `smooth-white` `#F5F7F8`,
+  `soft-black` `#333`.
+
+### Convenções
+- Rota nova entra em `app.routes.ts`; se autenticada, `canActivate: [authGuard]`.
+- RxJS: retorne `Observable`, componha com `pipe`. `unsubscribe` ou
+  `takeUntilDestroyed` em subscription manual dentro de componente.
+- Tipos de domínio em `interfaces/`. Evite `any` em assinatura pública.
+- **Escreva testes.** Existem 10 `.spec.ts` (Karma + Jasmine); arquivo novo
+  acompanha spec, mesmo mínimo.
+- Budget de build: 500 KB inicial (warning) / 1 MB (erro). Dependência pesada
+  precisa de justificativa.
+
+## Segurança
+- Nunca logue nem exponha JWT, senha ou conteúdo do `.env`.
+- Nunca proponha desabilitar CORS, CSRF ou validação como solução de bug.
+
+## Honestidade
+- Se não achar a causa raiz, diga. Liste o que descartou e o que falta.
+- Se faltar stacktrace ou resposta da API, peça. Não adivinhe.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# TheRogueDev Client — Instruções para Claude Code
+
+## Sobre
+
+Frontend da plataforma **TheRogueDev** — plataforma gamificada de aprendizado colaborativo (Angular 19, TypeScript, Tailwind CSS, SSR).
+
+Leia `FRONTEND.md` para o mapeamento completo do projeto antes de qualquer desenvolvimento.
+
+## Stack
+
+| Layer | Tech |
+|---|---|
+| Framework | Angular 19.2.0 (Standalone Components) |
+| Linguagem | TypeScript 5.7.2 |
+| Estilo | Tailwind CSS 4.1.13 + Angular Material 19.2.19 (tema Azure Blue) |
+| SSR | Angular Universal + Express |
+| HTTP | Angular HttpClient (`BaseApiService` existe mas ainda não é usada) |
+| Ícones | Font Awesome Free 7.1.0 |
+| Testes | Karma + Jasmine |
+
+## Estrutura Principal
+
+```
+src/app/
+├── component/        # Componentes reutilizáveis (header, footer)
+├── pages/            # Um componente por rota (home, login, register, user-profile)
+├── services/
+│   ├── base/         # BaseApiService — classe abstrata pronta, sem consumidores
+│   ├── auth/         # AuthService — usa HttpClient direto (legado)
+│   └── user/         # UserService — VAZIO, só o @Injectable
+├── guards/           # authGuard — protege rotas autenticadas
+├── interfaces/       # Modelos TypeScript (user.interface.ts)
+└── enviroments/      # Dev / prod / build (typo "enviroments" é intencional)
+```
+
+## Rotas
+
+| Path | Componente | Protegida |
+|---|---|---|
+| `/` | HomeComponent | Não |
+| `/login` | LoginComponent | Não |
+| `/register` | RegisterComponent | Não |
+| `/user` | UserProfileComponent | Sim (`authGuard`) |
+
+## Convenções Obrigatórias
+
+- **Standalone components** — não usar NgModules
+- Service **novo** estende `BaseApiService<T>`. Componente nunca chama `HttpClient` direto
+- Autenticação por **cookie HTTP-only** — não usar `localStorage` para token
+- Para código client-only, verificar `isPlatformBrowser()` (SSR ativo)
+- Novos componentes de página → `pages/<nome>/`
+- Novos componentes reutilizáveis → `component/<nome>/`
+- Novos serviços → `services/<domínio>/`
+- Novas interfaces → `interfaces/<domínio>/`
+- Criar spec file `.spec.ts` junto com cada componente/serviço
+
+## Tema de Cores (Tailwind)
+
+```
+primary-color:    #171F27  (background principal — dark blue)
+secondary-color:  #1E2933  (sidebar, cards)
+emerald:          #2EC0AD  (accent, CTAs)
+lg-grey:          #ACB8A3  (texto secundário)
+deep-dark:        #0E141B  (background mais escuro)
+smooth-white:     #F5F7F8  (texto claro, fundos claros)
+soft-black:       #333     (texto padrão)
+```
+
+## Estado real do código
+
+Verificado no fonte — a doc antiga descrevia um projeto mais completo:
+
+- **Nenhum service estende `BaseApiService`.** A classe abstrata está pronta
+  (get/post/put/patch/delete, query string, guarda de SSR, `catchError`)
+  mas ninguém a consome ainda.
+- `AuthService` usa `HttpClient` direto + `BehaviorSubject`. É legado; não replique.
+- **`UserService` está vazio** — sem `getProfile()`, sem `updateProfile()`.
+
+## Backend
+
+- URL (dev): `http://localhost:8080/api`
+- Autenticação: JWT via cookie HTTP-only (enviado automaticamente pelo browser)
+- CORS: backend aceita `http://localhost:4200`
+- OAuth2 Google: redireciona para o backend
+- Rotas são **singulares e hierárquicas**, não plural com hífen:
+  `/v1/auth/login`, `/v1/user`, `/v1/user/profile`, `/v1/forum/publication`,
+  `/v1/publication/topic`, `/v1/currency/virtual/user/wallet`.
+  Na dúvida, confira o `@RequestMapping` em `TheRogueDev-api`
+
+## Scripts
+
+```bash
+npm start           # Dev server → http://localhost:4200
+npm run build       # Build produção → dist/the-rogue-dev-client/
+npm test            # Testes Karma
+npm run serve:ssr   # Serve com SSR
+```

--- a/FRONTEND.md
+++ b/FRONTEND.md
@@ -1,0 +1,153 @@
+# TheRogueDev — Frontend Map
+
+## Stack
+
+| Layer | Tech |
+|---|---|
+| Language | TypeScript 5.7.2 |
+| Framework | Angular 19.2.0 |
+| Build | Angular CLI 19.2.15 |
+| Package Manager | npm |
+| Styling | Tailwind CSS 4.1.13 + Angular Material 19.2.19 |
+| Icons | Font Awesome Free 7.1.0 |
+| HTTP | Angular HttpClient |
+| SSR | Angular Universal + Express |
+| Testes | Karma + Jasmine |
+
+## Entry Points
+
+| Arquivo | Função |
+|---|---|
+| `src/main.ts` | Bootstrap da aplicação (client) |
+| `src/main.server.ts` | Bootstrap SSR |
+| `src/server.ts` | Servidor Express para SSR |
+| `src/app/app.config.ts` | Configuração Angular (providers) |
+| `src/app/app.routes.ts` | Definição de rotas |
+
+## Estrutura de Pastas
+
+```
+src/app/
+├── app.component.ts/.html/.css     # Root component (router-outlet + header + footer)
+├── app.config.ts                   # Providers: Router, HttpClient, Hydration
+├── app.routes.ts                   # Rotas da aplicação
+├── component/                      # Componentes reutilizáveis
+│   ├── header/                     # Navbar + menu do usuário + logout
+│   └── footer/                     # Footer estático
+├── pages/                          # Componentes de página (um por rota)
+│   ├── home/                       # Landing page (pública)
+│   ├── login/                      # Formulário login + OAuth2 Google
+│   ├── register/                   # Formulário de cadastro
+│   └── user-profile/               # Perfil do usuário (rota protegida)
+├── services/
+│   ├── base/
+│   │   └── base-api.service.ts     # Classe abstrata para HTTP (GET, POST, PUT, PATCH, DELETE)
+│   ├── auth/
+│   │   └── auth.service.ts         # Login, logout, validação de token
+│   └── user/
+│       └── user.service.ts         # Dados e atualização do perfil
+├── guards/
+│   └── auth.guard.ts               # Protege rotas autenticadas, redireciona se não autenticado
+├── interfaces/
+│   └── user/
+│       └── user.interface.ts       # Modelo de dados do usuário
+└── enviroments/
+    ├── enviroment.ts               # Dev: apiUrl = http://localhost:8080/api
+    ├── enviroment-prod.ts          # Prod: URL do backend em produção
+    └── enviroment.build.ts         # Build-time env
+```
+
+## Rotas
+
+| Path | Componente | Guard |
+|---|---|---|
+| `/` | `HomeComponent` | — |
+| `/login` | `LoginComponent` | — |
+| `/register` | `RegisterComponent` | — |
+| `/user` | `UserProfileComponent` | `authGuard` |
+
+## Serviços
+
+> **Estado verificado em 2026-08-29: nenhum service estende `BaseApiService`.**
+> A classe está pronta e é o alvo da arquitetura, mas ainda não tem consumidor.
+
+### `BaseApiService` (abstrato) — pronta, sem uso
+- Métodos protegidos: `get()`, `post()`, `put()`, `patch()`, `delete()`
+- Query string builder interno
+- Verifica se está rodando no browser (SSR safety)
+- Retorna `Observable<T>` com RxJS
+- **Service novo deve estendê-la.** Não copie o padrão do `AuthService`.
+
+### `AuthService` — legado, não estende a base
+Usa `HttpClient` direto + `BehaviorSubject` (`user$`) para o usuário logado.
+- `register(data)` → POST `/v1/auth/register`
+- `login(data)` → POST `/v1/auth/login`
+- `logout()` → POST `/v1/auth/logout`
+- `loadUser()` → GET `/v1/user`
+- JWT recebido e enviado via cookie HTTP-only (automático pelo browser)
+
+### `UserService` — **vazio**
+Só o `@Injectable` e um construtor sem corpo. Não existem `getProfile()` nem
+`updateProfile()`. Ao implementar, estenda `BaseApiService`.
+
+## Tema Visual
+
+**Tailwind Custom Colors** (`tailwind.config.js`):
+
+| Nome | Hex | Uso |
+|---|---|---|
+| `primary-color` | `#171F27` | Background principal (dark blue) |
+| `secondary-color` | `#1E2933` | Sidebar / cards |
+| `emerald` | `#2EC0AD` | Accent / CTA |
+| `lg-grey` | `#ACB8A3` | Texto secundário |
+| `deep-dark` | `#0E141B` | Background mais escuro |
+| `smooth-white` | `#F5F7F8` | Texto claro / backgrounds claros |
+| `soft-black` | `#333` | Texto padrão |
+
+**Material Theme:** Azure Blue
+
+## Scripts
+
+```bash
+npm start           # ng serve → http://localhost:4200
+npm run build       # Build produção → dist/the-rogue-dev-client
+npm run watch       # Build contínuo (dev)
+npm test            # Testes com Karma
+npm run serve:ssr   # Produção com SSR
+```
+
+## Configuração Angular (app.config.ts)
+
+```typescript
+provideZoneChangeDetection({ eventCoalescing: true })
+provideRouter(routes)
+provideClientHydration(withEventReplay())  // SSR hydration
+provideHttpClient()
+```
+
+## Convenções do Projeto
+
+- **Standalone components** (Angular 19, sem NgModules)
+- Um componente por página na pasta `pages/`
+- Componentes reutilizáveis em `component/`
+- Service novo estende `BaseApiService` (nenhum estende hoje — `AuthService` é legado)
+- Autenticação via cookie HTTP-only (sem localStorage para token)
+- Arquivos de ambiente em `enviroments/` (typo intencional no projeto)
+- Spec files `.spec.ts` para todos componentes e serviços
+- SSR habilitado — verificar `isPlatformBrowser()` para código client-only
+
+## Comunicação com o Backend
+
+- Base URL (dev): `http://localhost:8080/api`; o caminho começa em `/v1/...`
+- Rotas do backend são **singulares e hierárquicas**, não plural com hífen:
+  `/v1/user`, `/v1/user/profile`, `/v1/forum/publication`, `/v1/publication/topic`,
+  `/v1/currency/virtual/user/wallet`, `/v1/image`
+- Autenticação: cookie HTTP-only com JWT (enviado automaticamente)
+- CORS configurado no backend para aceitar `http://localhost:4200`
+- Google OAuth2: redireciona para backend → `{backendUrl}/login/oauth2/code/google`
+
+## Build Output
+
+- Dev output: `dist/the-rogue-dev-client/`
+- Budget: 500KB initial (warning), 1MB (error)
+- Produção: otimização, hash de assets, lazy loading


### PR DESCRIPTION
Adiciona FRONTEND.md e CLAUDE.md descrevendo o estado REAL do codigo, verificado no fonte da main:
- BaseApiService existe e esta completa, mas nenhum service a estende
- AuthService usa HttpClient direto + BehaviorSubject (legado)
- UserService esta vazio: sem getProfile(), sem updateProfile()
- rotas do backend sao singulares e hierarquicas (/v1/user/profile, /v1/forum/publication), nao plural com hifen

Adiciona AGENTS.md e .continue/rules/ para os modelos locais via Ollama, com globs por tipo de arquivo para economizar a janela de contexto.

.gitignore: passa a ignorar .env (nao estava), *.pem e a pasta .angular inteira — antes so /.angular/cache estava coberto.